### PR TITLE
tweak: allow open device page by clicking device name tag

### DIFF
--- a/packages/app/src/components/device/device-name.tsx
+++ b/packages/app/src/components/device/device-name.tsx
@@ -12,7 +12,7 @@ import { Label } from "@radix-ui/react-label";
 import { useQuery } from "@tanstack/react-query";
 import { VariantProps } from "class-variance-authority";
 import { memo } from "react";
-import { useNavigate, Link } from "react-router";
+import { Link } from "react-router";
 
 export interface DeviceNameProps {
   deviceId: string;
@@ -24,7 +24,6 @@ type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
 
 export const DeviceName = memo(
   ({ deviceId, configurationName, name }: DeviceNameProps) => {
-    const navigate = useNavigate();
     const isAllowedToViewStream = useIsPermitted("view-stream");
     const isAllowedToControlDevice = useIsPermitted("control-device");
     const { isSupported: isHealthcheckSupported } = useIsSupported(
@@ -71,7 +70,7 @@ export const DeviceName = memo(
               >
                 {isAllowedToControlDevice ? (
                   <Link to={`/${deviceId}`} className="self-center">
-                    <Label>{name}</Label>
+                    <span>{name}</span>
                   </Link>
                 ) : (
                   <Label>{name}</Label>

--- a/packages/app/src/components/device/device-name.tsx
+++ b/packages/app/src/components/device/device-name.tsx
@@ -12,6 +12,7 @@ import { Label } from "@radix-ui/react-label";
 import { useQuery } from "@tanstack/react-query";
 import { VariantProps } from "class-variance-authority";
 import { memo } from "react";
+import { useNavigate, Link } from "react-router";
 
 export interface DeviceNameProps {
   deviceId: string;
@@ -23,7 +24,9 @@ type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
 
 export const DeviceName = memo(
   ({ deviceId, configurationName, name }: DeviceNameProps) => {
+    const navigate = useNavigate();
     const isAllowedToViewStream = useIsPermitted("view-stream");
+    const isAllowedToControlDevice = useIsPermitted("control-device");
     const { isSupported: isHealthcheckSupported } = useIsSupported(
       deviceId ?? "",
       "healthcheck"
@@ -66,7 +69,13 @@ export const DeviceName = memo(
                 variant={getBadgeVariant()}
                 className="text-md transition-all duration-300"
               >
-                <Label>{name}</Label>
+                {isAllowedToControlDevice ? (
+                  <Link to={`/${deviceId}`} className="self-center">
+                    <Label>{name}</Label>
+                  </Link>
+                ) : (
+                  <Label>{name}</Label>
+                )}
               </Badge>
             </TooltipTrigger>
             <TooltipContent side="right" sideOffset={30}>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add clickable device name functionality for authorized users

- Implement navigation to device page via name tag

- Add permission check for control-device access


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Device Name Badge"] --> B["Permission Check"]
  B --> C["control-device allowed?"]
  C -->|Yes| D["Clickable Link to Device Page"]
  C -->|No| E["Static Label"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>device-name.tsx</strong><dd><code>Enable clickable device name navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/app/src/components/device/device-name.tsx

<li>Import <code>useNavigate</code> and <code>Link</code> from react-router<br> <li> Add <code>isAllowedToControlDevice</code> permission check<br> <li> Wrap device name label in Link component conditionally<br> <li> Enable navigation to device page when clicking name


</details>


  </td>
  <td><a href="https://github.com/skylineagle/joystick/pull/23/files#diff-100ac469d6be5aa013c7813e6270ca6e3e079c8dbade70e80c9006bc7e13a77c">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>