### PR TITLE
fix: use the right param for send message

### DIFF
--- a/packages/app/src/pages/messages/new-message.tsx
+++ b/packages/app/src/pages/messages/new-message.tsx
@@ -18,7 +18,7 @@ export const NewMessage = ({ deviceId }: NewMessageProps) => {
         success: boolean;
         output: string;
       }>(`${urls.joystick}/api/run/${deviceId}/send-sms`, {
-        message: input,
+        sms: input,
       });
 
       try {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix parameter name in SMS sending API call


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NewMessage Component"] -- "sends request with" --> B["API Endpoint"]
  B -- "expects 'sms' parameter" --> C["SMS Service"]
  A -- "was sending 'message'" --> D["Wrong Parameter"]
  D -- "fixed to 'sms'" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-message.tsx</strong><dd><code>Fix SMS API parameter name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/app/src/pages/messages/new-message.tsx

- Changed parameter name from `message` to `sms` in API request body


</details>


  </td>
  <td><a href="https://github.com/skylineagle/joystick/pull/30/files#diff-be771499705b222269411f2d18f4dc205f67424add2744f2147e4245976121dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

