### PR TITLE
fix: whisper webhook types

### DIFF
--- a/packages/whisper/src/index.ts
+++ b/packages/whisper/src/index.ts
@@ -93,7 +93,7 @@ const app = new Elysia()
   // Unauthenticated endpoint for receiving SMS
   .post("/api/receive-sms", async ({ body: rawBody, set }) => {
     const body = rawBody as WebhookEvent;
-    const event = "event" in body ? body.event : undefined;
+    const event = body.event;
     const message =
       "message" in body
         ? body.message

--- a/packages/whisper/src/types.ts
+++ b/packages/whisper/src/types.ts
@@ -32,7 +32,9 @@ export type AndroidSmsGatewayEvent = {
   payload?: WebHookPayload;
 };
 
-export type WebhookEvent = AndroidSmsGatewayEvent | WebHookPayload;
+export type WebhookEvent =
+  | AndroidSmsGatewayEvent
+  | ({ event: string } & WebHookPayload);
 
 export interface PendingSmsMessage {
   resolve: (value: SmsResponse) => void;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Refactor webhook event type definitions for clarity

- Simplify SMS webhook endpoint implementation

- Remove redundant Elysia body validation schema


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["WebhookEvent union type"] --> B["AndroidSmsGatewayEvent + WebHookPayload"]
  C["SMS endpoint"] --> D["Simplified type handling"]
  E["Body validation"] --> F["Removed Elysia schema"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Simplify SMS webhook endpoint implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/whisper/src/index.ts

<ul><li>Import new <code>AndroidSmsGatewayEvent</code> type<br> <li> Simplify <code>/api/receive-sms</code> endpoint with explicit type casting<br> <li> Remove complex Elysia body validation schema<br> <li> Streamline webhook event property extraction logic</ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/joystick/pull/31/files#diff-20ed455def74a21a0fd2e774d249be3858f2fdfeaa88962e049f2af56e91c552">+49/-62</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Refactor webhook event type definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/whisper/src/types.ts

<ul><li>Split <code>WebhookEvent</code> union type into separate types<br> <li> Create dedicated <code>AndroidSmsGatewayEvent</code> interface<br> <li> Redefine <code>WebhookEvent</code> as union of <code>AndroidSmsGatewayEvent</code> and <br><code>WebHookPayload</code></ul>


</details>


  </td>
  <td><a href="https://github.com/skylineagle/joystick/pull/31/files#diff-40704846636a06ece846daff1a24768c356451660c40ad2973ee62f31f5c092c">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

