### PR TITLE
Dev tools package, permission gaps migration, cleanup

### DIFF
--- a/pocketbase/pb_migrations/1776101610_permission_gaps.js
+++ b/pocketbase/pb_migrations/1776101610_permission_gaps.js
@@ -1,0 +1,102 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+/*
+ Full inventory of permission names used by the Joystick app (useIsPermitted
+ and useIsRouteAllowed, which checks "<route>-route"):
+
+ action-route, admin-dashboard, advanced-stream-control, audio-route,
+ cell-search, cell-search-route, control-device, control-mode, control-ptz,
+ control-roi, create-device, delete-device, device-battery, device-cpsi,
+ device-gps, device-imu, device-ping, device-temp, download-client,
+ easter-eggs, edit-configuration, edit-device, gallery-route, media-route,
+ message-route, notifications, notifications-history, parameters-route,
+ recent-events, system-status, terminal-route, toggle-slot, view-stream
+
+ Prior pb_migrations already insert rows for every name in that list except:
+ admin-dashboard, control-device, create-device, delete-device,
+ download-client, easter-eggs, edit-configuration, edit-device, recent-events,
+ view-stream
+
+ This migration creates those missing permission records (if absent) and
+ ensures admin@joystick.io is in `users`, merging into existing rows when
+ present.
+*/
+
+const GAP_PERMISSION_NAMES = [
+  "admin-dashboard",
+  "control-device",
+  "create-device",
+  "delete-device",
+  "download-client",
+  "easter-eggs",
+  "edit-configuration",
+  "edit-device",
+  "recent-events",
+  "view-stream",
+];
+
+const mergeAdminUser = (record, adminId) => {
+  let userIds = record.get("users");
+  if (!userIds) {
+    userIds = [];
+  }
+  if (!Array.isArray(userIds)) {
+    userIds = [];
+  }
+  if (userIds.includes(adminId)) {
+    return false;
+  }
+  record.set("users", [...userIds, adminId]);
+  return true;
+};
+
+migrate(
+  (app) => {
+    const permissionsCollection = app.findCollectionByNameOrId("permissions");
+    const adminUsers = app.findRecordsByFilter(
+      "users",
+      "email = 'admin@joystick.io'"
+    );
+    if (adminUsers.length === 0) {
+      return;
+    }
+    const adminId = adminUsers[0].id;
+
+    for (const name of GAP_PERMISSION_NAMES) {
+      let existing = null;
+      try {
+        existing = app.findFirstRecordByFilter(
+          "permissions",
+          `name = '${name}'`
+        );
+      } catch (e) {
+        existing = null;
+      }
+
+      if (existing) {
+        if (mergeAdminUser(existing, adminId)) {
+          app.save(existing);
+        }
+        continue;
+      }
+
+      const created = new Record(permissionsCollection);
+      created.set("name", name);
+      created.set("users", [adminId]);
+      app.save(created);
+    }
+  },
+  (app) => {
+    for (const name of GAP_PERMISSION_NAMES) {
+      try {
+        const record = app.findFirstRecordByFilter(
+          "permissions",
+          `name = '${name}'`
+        );
+        if (record) {
+          app.dao().deleteRecord(record);
+        }
+      } catch (e) {}
+    }
+  }
+);


### PR DESCRIPTION
Adds packages/dev-tools (device mock, seed helpers), PocketBase migration 1776101610_permission_gaps.js for missing admin permissions (including control-device), updates root deps and pb_data/types.d.ts, removes local PocketBase backup zips from the repo.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authorization data by creating/deleting permission records and assigning them to `admin@joystick.io`, which can change access control if names or user selection are incorrect.
> 
> **Overview**
> Adds a PocketBase migration (`1776101610_permission_gaps.js`) that **backfills missing `permissions` records** for a defined set of permission names and **ensures `admin@joystick.io` is included** in each permission’s `users` list (merging into existing records when present).
> 
> The down migration deletes permission records for those names, potentially removing them regardless of whether they pre-existed this migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3e59a90a4fc99214edb584c98e0c7c6a283d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->